### PR TITLE
Fix initialization issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -213,3 +213,10 @@ def lcdjob(api):
         lcd.cursor_pos = (3, 0)
         lcd.write_string((strftime(u"%Y-%m-%d %H:%M:%S", time.localtime())).ljust(20))
     pass
+
+@cbpi.initalizer(order=1)
+def init_lcddisplay(self):
+    app.config['LCD_Adress'] = set_lcd_adress()
+    app.config['LCD_Refresh'] = set_parameter_refresh()
+    app.config['LCD_Multidisplay'] = set_parameter_multidisplay()
+    app.config['LCD_Singledisplay'] = set_parameter_id1()


### PR DESCRIPTION
[__init__.py.txt](https://github.com/breiti78/craftbeerpiLCD/files/1282136/__init__.py.txt)

Just put everything in the initalizer block. Oder 2100 because I wantet to start after steps. This because I always get a none on the LCD when restarting during mashstep.

There is an other posibility:
Just define a small initializer block (like carl suggestd) but with global variable.
This behaves the same as the example above but codewise more handy.
I would prefer this version:

[__init__.py.txt](https://github.com/breiti78/craftbeerpiLCD/files/1282281/__init__.py.txt)


Please use ether the first init file or the one at the end of this text.
In the resend merge there are some strage signs etc. 
